### PR TITLE
URLSearchParams constructor is missing the array tuple and record form

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -896,7 +896,7 @@ declare class Headers {
 
 declare class URLSearchParams {
     @@iterator(): Iterator<[string, string]>;
-    constructor(query?: string | URLSearchParams): void;
+    constructor(query?: string | URLSearchParams | Array<[string, string]> | {[string]: string} ): void;
     append(name: string, value: string): void;
     delete(name: string): void;
     entries(): Iterator<[string, string]>;


### PR DESCRIPTION
See https://url.spec.whatwg.org/#urlsearchparams
 | Array<[string, string]> | {[string]: string}